### PR TITLE
Fix toolbar jump

### DIFF
--- a/app/src/main/res/layout/activity_splash.xml
+++ b/app/src/main/res/layout/activity_splash.xml
@@ -2,8 +2,7 @@
 
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:background="@color/primaryBlue500">
+    android:layout_height="match_parent">
 
     <ImageView
         android:layout_width="@dimen/splash_logo_diameter"

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -2,11 +2,13 @@
 
 <resources>
 
-    <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
+    <style name="primaryColorsTheme" parent="Theme.AppCompat.Light.NoActionBar">
         <item name="colorPrimary">@color/primaryBlue500</item>
         <item name="colorPrimaryDark">@color/primaryBlue700</item>
         <item name="colorAccent">@color/accentPinkA200</item>
+    </style>
 
+    <style name="AppTheme" parent="primaryColorsTheme">
         <item name="searchViewStyle">@style/SearchViewStyle</item>
 
         <item name="android:textColorHighlight">#99ff4081</item>
@@ -17,10 +19,9 @@
         <item name="android:fastScrollThumbDrawable">@drawable/fastscroll_thumb</item>
     </style>
 
-    <style name="SplashTheme" parent="Theme.AppCompat.NoActionBar">
+    <style name="SplashTheme" parent="primaryColorsTheme">
         <item name="android:windowNoTitle">true</item>
         <item name="windowActionBar">false</item>
-        <item name="android:windowFullscreen">true</item>
         <item name="android:windowContentOverlay">@null</item>
     </style>
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -20,6 +20,7 @@
     </style>
 
     <style name="SplashTheme" parent="primaryColorsTheme">
+        <item name="android:background">@color/primaryBlue500</item>
         <item name="android:windowNoTitle">true</item>
         <item name="windowActionBar">false</item>
         <item name="android:windowContentOverlay">@null</item>


### PR DESCRIPTION
When you launch the app the toolbar jumps a little as you go from the splash activity to the main activity, but not anymore. My fix is to stop the splash screen being a fullscreen activity